### PR TITLE
Fix typo in bindUIDraggableEvents

### DIFF
--- a/content/methods.html
+++ b/content/methods.html
@@ -163,7 +163,7 @@ pckry.bindResize()
 <h2>bindUIDraggableEvents</h2>
 
 ``` js
-$container.packery( 'bindDraggabillyEvents', $elements )
+$container.packery( 'bindUIDraggableEvents', $elements )
 // or with vanilla JS
 pckry.bindUIDraggableEvents( $elements )
 ```

--- a/content/methods.html
+++ b/content/methods.html
@@ -510,9 +510,9 @@ pckry.on( 'layoutComplete', function() {
 <h2>once</h2>
 
 ``` js
-var pckry = $container.packery( 'on', eventName, listener )
+var pckry = $container.packery( 'once', eventName, listener )
 // or with vanilla JS
-pckry.on( eventName, listener )
+pckry.once( eventName, listener )
 ```
 
 <p>Add an event listener for <a href="events.html">certain events</a>, to be triggered once.</p>


### PR DESCRIPTION
Didn't confirm that this is change works, but it looks like this was the intended code.